### PR TITLE
Fixed .split on tripsign for route 99 sometimes crashing the app

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -339,11 +339,11 @@ async function UpdateMarkers(fetchNewData)
 
             let labelText = bus.routeShortName;
             
-            if(labelText === '99')
+            if (labelText === '99')
             {
                 let splitHeadsign = bus.tripHeadsign.split(' ');
 
-                if(splitHeadsign.length > 2)
+                if (splitHeadsign.length > 2)
                 {
                     labelText += bus.tripHeadsign.split(' ')[2].charAt(0);
                 }

--- a/public/index.js
+++ b/public/index.js
@@ -341,7 +341,12 @@ async function UpdateMarkers(fetchNewData)
             
             if(labelText === '99')
             {
-                labelText += bus.tripHeadsign.split(' ')[2].charAt(0)
+                let splitHeadsign = bus.tripHeadsign.split(' ');
+
+                if(splitHeadsign.length > 2)
+                {
+                    labelText += bus.tripHeadsign.split(' ')[2].charAt(0);
+                }
             }
 
             let marker = new google.maps.Marker(


### PR DESCRIPTION
Sometimes the tripsign for the 99 is just "99 Mainline" instead of "99 Mainline Northbound" or "99 Mainline Southbound" and then this string split would crash since there is only 2 words. 

Fixed with a length check.